### PR TITLE
Honor NPM's cafile configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,15 @@ var debug = require('debug')('nugget')
 
 function noop () {}
 
+// from node-gyp
+function readCAFile (filename) {
+  // The CA file can contain multiple certificates so split on certificate
+  // boundaries.  [\S\s]*? is used to match everything including newlines.
+  var ca = fs.readFileSync(filename, 'utf8')
+  var re = /(-----BEGIN CERTIFICATE-----[\S\s]*?-----END CERTIFICATE-----)/g
+  return ca.match(re)
+}
+
 module.exports = function(urls, opts, cb) {
   if (!Array.isArray(urls)) urls = [urls]
   if (urls.length === 1) opts.singleTarget = true
@@ -27,6 +36,12 @@ module.exports = function(urls, opts, cb) {
 
   if (opts.strictSSL !== null) {
     defaultProps.strictSSL = opts.strictSSL
+  }
+
+  var cafile = opts.cafile || process.env.npm_config_cafile;
+
+  if (cafile) {
+    defaultProps.ca = readCAFile(cafile)
   }
 
   if (Object.keys(defaultProps).length > 0) {


### PR DESCRIPTION
If you are behind a corporate firewall with a self-signed certificate, the correct way to configure node and npm is to use `npm config set cafile="/path/to/cert.pem"`

This PR honors this configuration being passed to the request library in the same manner that node-gyp does (using the same readCAFile function, to boot)
