### PR TITLE
Use minimist to create alias and default arguments

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -26,7 +26,7 @@ var opts = require('minimist')(process.argv.slice(2), {
     resume: 'continue',
     strictSSL: 'strict-ssl'
   }
-});
+})
 
 var urls = opts._
 if (urls.length === 0) {
@@ -35,7 +35,7 @@ if (urls.length === 0) {
 }
 
 if (opts.frequency) {
-  opts.frequency = +opts.frequency; 
+  opts.frequency = +opts.frequency
 }
 
 nugget(urls, opts, function (err) {

--- a/bin.js
+++ b/bin.js
@@ -3,24 +3,39 @@
 var fs = require('fs')
 var path = require('path')
 var nugget = require('./')
-var args = require('minimist')(process.argv.slice(2))
+var opts = require('minimist')(process.argv.slice(2), {
+  string: ['out', 'dir'],
+  boolean: ['continue', 'force', 'quiet', 'strict-ssl'],
+  default: {
+    continue: false,
+    force: false,
+    quiet: false,
+    'strict-ssl': true,
+    proxy: null,
+    frequency: null
+  },
+  alias: {
+    o: 'out',
+    O: 'out',
+    d: 'dir',
+    c: 'continue',
+    f: 'force',
+    s: 'sockets',
+    q: 'quiet',
+    target: 'out',
+    resume: 'continue',
+    strictSSL: 'strict-ssl'
+  }
+});
 
-var urls = args._
+var urls = opts._
 if (urls.length === 0) {
   console.log(fs.readFileSync(path.join(__dirname, 'usage.txt')).toString())
   process.exit(1)
 }
 
-var opts = {
-  target: args.o || args.O || args.out,
-  dir: args.d || args.dir,
-  resume: args.c || args.continue,
-  force: args.f || args.force,
-  sockets: args.s || args.sockets,
-  quiet: args.q || args.quiet,
-  frequency: args.frequency ? +args.frequency : null,
-  proxy: args.proxy ? args.proxy : null,
-  strictSSL: args['strict-ssl']
+if (opts.frequency) {
+  opts.frequency = +opts.frequency; 
 }
 
 nugget(urls, opts, function (err) {


### PR DESCRIPTION
Love the module, I'm a big fan. Thanks for creating and supporting it.

I have a pretty simple PR that updates the bin entry point to take advantage of **minimist**'s options for defining aliases, defaults, booleans and strings.  It uses minimist's parse arguments return instead of creating a new object. Also, it's nicer to have these things be explicitly declared. 

If you're happy with the existing arguments/options setup, please feel free to close. 