### PR TITLE
bump pretty-bytes to ^4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "debug": "^2.1.3",
     "minimist": "^1.1.0",
-    "pretty-bytes": "^1.0.2",
+    "pretty-bytes": "^4.0.2",
     "progress-stream": "^1.1.0",
     "request": "^2.45.0",
     "single-line-log": "^1.1.2",


### PR DESCRIPTION
pretty-bytes has a nth-level dependency with a security vulnerability (parse-json which vendors in unicode.js) bumping pretty-bytes significantly reduces the number of dependencies.

npm list results:

before:
```
├─┬ pretty-bytes@1.0.4
│ ├── get-stdin@4.0.1
│ └─┬ meow@3.7.0
│   ├─┬ camelcase-keys@2.1.0
│   │ ├── camelcase@2.1.1
│   │ └── map-obj@1.0.1 deduped
│   ├── decamelize@1.2.0
│   ├─┬ loud-rejection@1.6.0
│   │ ├─┬ currently-unhandled@0.4.1
│   │ │ └── array-find-index@1.0.2
│   │ └── signal-exit@3.0.2
│   ├── map-obj@1.0.1
│   ├── minimist@1.2.0 deduped
│   ├─┬ normalize-package-data@2.4.0
│   │ ├── hosted-git-info@2.5.0
│   │ ├─┬ is-builtin-module@1.0.0
│   │ │ └── builtin-modules@1.1.1
│   │ ├── semver@5.4.1
│   │ └─┬ validate-npm-package-license@3.0.1
│   │   ├─┬ spdx-correct@1.0.2
│   │   │ └── spdx-license-ids@1.2.2
│   │   └── spdx-expression-parse@1.0.4
│   ├── object-assign@4.1.1
│   ├─┬ read-pkg-up@1.0.1
│   │ ├─┬ find-up@1.1.2
│   │ │ ├─┬ path-exists@2.1.0
│   │ │ │ └── pinkie-promise@2.0.1 deduped
│   │ │ └─┬ pinkie-promise@2.0.1
│   │ │   └── pinkie@2.0.4
│   │ └─┬ read-pkg@1.1.0
│   │   ├─┬ load-json-file@1.1.0
│   │   │ ├── graceful-fs@4.1.11 deduped
│   │   │ ├─┬ parse-json@2.2.0
│   │   │ │ └─┬ error-ex@1.3.1
│   │   │ │   └── is-arrayish@0.2.1
│   │   │ ├── pify@2.3.0
│   │   │ ├── pinkie-promise@2.0.1 deduped
│   │   │ └─┬ strip-bom@2.0.0
│   │   │   └── is-utf8@0.2.1
│   │   ├── normalize-package-data@2.4.0 deduped
│   │   └─┬ path-type@1.1.0
│   │     ├── graceful-fs@4.1.11 deduped
│   │     ├── pify@2.3.0 deduped
│   │     └── pinkie-promise@2.0.1 deduped
│   ├─┬ redent@1.0.0
│   │ ├─┬ indent-string@2.1.0
│   │ │ └─┬ repeating@2.0.1
│   │ │   └─┬ is-finite@1.0.2
│   │ │     └── number-is-nan@1.0.1 deduped
│   │ └─┬ strip-indent@1.0.1
│   │   └── get-stdin@4.0.1 deduped
│   └── trim-newlines@1.0.0
```

after:
```
├── pretty-bytes@4.0.2
```